### PR TITLE
[WIP] Add nginx proxy for routing

### DIFF
--- a/openshift/proxy/nginx.configmap.yaml
+++ b/openshift/proxy/nginx.configmap.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: launchpad-nginx
+data:
+  nginx.conf: |-
+    daemon off;
+
+    error_log /dev/stdout debug;
+    pid /run/nginx.pid; 
+
+    events {
+        worker_connections  1024;
+    }
+
+    http {
+
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log /dev/stdout;
+
+        access_log          /dev/stdout main;                                                                                                                                                                                              
+        client_body_temp_path /tmp;                                                                                                                                                                                                        
+        fastcgi_temp_path /tmp;                                                                                                                                                                                                            
+        scgi_temp_path /tmp;                                                                                                                                                                                                               
+        proxy_temp_path /tmp;                                                                                                                                                                                                              
+        uwsgi_temp_path /tmp;                                                                                                                                                                                                              
+        sendfile            on;                                                                                                                                                                                                            
+        tcp_nopush          on;                                                                                                                                                                                                            
+        tcp_nodelay         on;                                                                                                                                                                                                            
+        keepalive_timeout   65;                                                                                                                                                                                                            
+        types_hash_max_size 2048;                                                                                                                                                                                                          
+                                                                                                                                                                                                                                          
+        include             /etc/nginx/mime.types;   
+        
+        upstream backend {
+          server launchpad-backend:8080;
+        }      
+
+        upstream frontend {
+          server launchpad-frontend:8080;
+        }      
+
+        upstream missioncontrol {
+          server launchpad-missioncontrol:8080;
+        }                 
+
+
+        server {
+
+            client_body_temp_path /tmp/nginx_client_temp 1 2;
+
+            listen       8080;
+            root         /usr/share/nginx/html;
+
+            
+
+            location / {
+              add_header 'Access-Control-Allow-Origin' "$http_origin";
+              add_header 'Access-Control-Allow-Credentials' 'true';
+              add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+
+              proxy_pass http://frontend/;
+            }
+
+            location /status/ {
+              add_header 'Access-Control-Allow-Origin' "$http_origin";
+              add_header 'Access-Control-Allow-Credentials' 'true';
+              add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+
+              proxy_pass http://missioncontrol/status/;
+            }
+
+            location /launchpad/ {
+              add_header 'Access-Control-Allow-Origin' "$http_origin";
+              add_header 'Access-Control-Allow-Credentials' 'true';
+              add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, OPTIONS';
+
+              proxy_pass http://backend/launchpad/;
+            }
+        }
+    }
+
+
+

--- a/openshift/proxy/nginx.yaml
+++ b/openshift/proxy/nginx.yaml
@@ -38,7 +38,7 @@ objects:
           run: launchpad-nginx
       spec:
         containers:
-        - image: registry.centos.org/kbsingh/openshift-nginx:$TAG
+        - image: registry.centos.org/kbsingh/openshift-nginx:$IMAGE_TAG
           imagePullPolicy: Always
           name: launchpad-nginx
           ports:

--- a/openshift/proxy/nginx.yaml
+++ b/openshift/proxy/nginx.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: launchpad-nginx
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: null
+    generation: 1
+    labels:
+      run: launchpad-nginx
+    name: launchpad-nginx
+  spec:
+    replicas: 1
+    selector:
+      run: launchpad-nginx
+    strategy:
+      resources:
+        requests:
+          cpu: 20m
+          memory: 20Mi
+        limits:
+          cpu: 200m
+          memory: 200Mi
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          run: launchpad-nginx
+      spec:
+        containers:
+        - image: registry.centos.org/kbsingh/openshift-nginx:$TAG
+          imagePullPolicy: Always
+          name: launchpad-nginx
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          volumeMounts:
+          - mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf 
+            name: configmap-volume
+        volumes:
+        - name: configmap-volume
+          configMap:
+            name: launchpad-neginx
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    name: launchpad-nginx
+  spec:
+    ports:
+    - name: "8080"
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      run: launchpad-nginx
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+- apiVersion: v1
+  kind: Route
+  metadata: 
+    name: launchpad-nginx
+  spec:
+    to:
+      kind: Service
+      name: launchpad-nginx
+      weight: 100
+    wildcardPolicy: None
+  status: {}
+parameters:
+- name: IMAGE_TAG
+  value: latest

--- a/openshift/proxy/nginx.yaml
+++ b/openshift/proxy/nginx.yaml
@@ -35,7 +35,7 @@ objects:
           run: launchpad-nginx
       spec:
         containers:
-        - image: registry.centos.org/kbsingh/openshift-nginx:$IMAGE_TAG
+        - image: registry.centos.org/kbsingh/openshift-nginx:${IMAGE_TAG}
           imagePullPolicy: Always
           name: launchpad-nginx
           ports:
@@ -49,7 +49,7 @@ objects:
         volumes:
         - name: configmap-volume
           configMap:
-            name: launchpad-neginx
+            name: launchpad-nginx
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}

--- a/openshift/proxy/nginx.yaml
+++ b/openshift/proxy/nginx.yaml
@@ -1,13 +1,11 @@
 apiVersion: v1
 kind: Template
-metadata:
-  creationTimestamp: null
+metadata:  
   name: launchpad-nginx
 objects:
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:
-    creationTimestamp: null
     generation: 1
     labels:
       run: launchpad-nginx
@@ -33,7 +31,6 @@ objects:
       type: Rolling
     template:
       metadata:
-        creationTimestamp: null
         labels:
           run: launchpad-nginx
       spec:
@@ -64,7 +61,6 @@ objects:
 - apiVersion: v1
   kind: Service
   metadata:
-    creationTimestamp: null
     name: launchpad-nginx
   spec:
     ports:


### PR DESCRIPTION
This is a first stab on replacing OpenShift routing with nginx reverse proxy.

There 2 major things which need to be resolved:

1. Image - the image I am using is built from "nginx-tesing" repository, I'll figure out if it's ok for prod by the end of the day
2. List of methods - I basically added all the methods to the redirect, but maybe that is not necessary - could you please review which are needed and which are not?

Once this is finished, we should be able to replace https://github.com/openshiftio/launchpad-frontend/blob/master/openshift/template.yaml#L18 with a configMap value and potentially remove the routes from frontend.

Sorry for the delay