### PR TITLE
change error_log level from debug to error

### DIFF
--- a/cico/root/etc/nginx/nginx.conf
+++ b/cico/root/etc/nginx/nginx.conf
@@ -1,6 +1,6 @@
 daemon off;
 
-error_log /dev/stdout debug;
+error_log /dev/stdout error;
 pid /run/nginx.pid;
 
 events {


### PR DESCRIPTION
This is currently running in production with the debug level causing between 100 to 200 new log entries per second.