### PR TITLE
Add LAUNCHER_MISSIONCONTROL_OPENSHIFT_IMPERSONATE_USER and LAUNCHER_MISSIONCONTROL_OPENSHIFT_TOKEN parameters

### DIFF
--- a/openshift/launcher-template.yaml
+++ b/openshift/launcher-template.yaml
@@ -40,12 +40,16 @@ parameters:
   value:
 - name: LAUNCHER_MISSIONCONTROL_OPENSHIFT_USERNAME
   displayName: OpenShift user name
-  description: OpenShift user (leave empty when using Keycloak)
+  description: OpenShift user (leave empty when using Keycloak with OpenShift as an Identity Provider or token)
   value: developer
 - name: LAUNCHER_MISSIONCONTROL_OPENSHIFT_PASSWORD
   displayName: OpenShift password
-  description: OpenShift password (leave empty when using Keycloak)  
+  description: OpenShift password (leave empty when using Keycloak with OpenShift as an Identity Provider or token)
   value: developer
+- name: LAUNCHER_MISSIONCONTROL_OPENSHIFT_IMPERSONATE_USER
+  displayName: Impersonate OpenShift users
+  description: Impersonate OpenShift users (requires a ServiceAccount with self-provisioner role)
+  value:
 - name: LAUNCHER_KEYCLOAK_URL
   displayName: KeyCloak URL
   description: The URL (with the /auth part) of a Keycloak installation to perform SSO
@@ -186,6 +190,10 @@ parameters:
 - name: CONTROLLER_IMAGE_TAG
   value: 2.3.7
   required: true
+- name: LAUNCHER_MISSIONCONTROL_OPENSHIFT_TOKEN
+  displayName: OpenShift token
+  description: OpenShift token (leave empty when using Keycloak with OpenShift as an Identity Provider or user/password above)
+  value:
 objects:
 - kind: ConfigMap
   apiVersion: v1
@@ -196,6 +204,7 @@ objects:
     launcher.missioncontrol.github.token: ${LAUNCHER_MISSIONCONTROL_GITHUB_TOKEN}
     launcher.missioncontrol.openshift.username: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_USERNAME}
     launcher.missioncontrol.openshift.password: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_PASSWORD}
+    launcher.missioncontrol.openshift.impersonate.user: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_IMPERSONATE_USER}
     launcher.missioncontrol.openshift.api.url: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_API_URL}
     launcher.missioncontrol.openshift.console.url: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL}
     launcher.backend.artemis.url: ${LAUNCHER_BACKEND_ARTEMIS_URL}
@@ -356,6 +365,18 @@ objects:
               configMapKeyRef:
                 name: launcher
                 key: launcher.missioncontrol.openshift.password
+                optional: true
+          - name: LAUNCHER_MISSIONCONTROL_OPENSHIFT_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: launcher
+                key: launcher.missioncontrol.openshift.token
+                optional: true
+          - name: LAUNCHER_MISSIONCONTROL_OPENSHIFT_IMPERSONATE_USER
+            valueFrom:
+              configMapKeyRef:
+                name: launcher
+                key: launcher.missioncontrol.openshift.impersonate.user
                 optional: true
           - name: LAUNCHER_MISSIONCONTROL_GITHUB_USERNAME
             valueFrom:
@@ -678,4 +699,5 @@ objects:
     name: launcher
   data:
     launcher.missioncontrol.openshift.clusters.subscription.token:
+    launcher.missioncontrol.openshift.token: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_TOKEN}
 

--- a/openshift/split/launcher-configmaps.yaml
+++ b/openshift/split/launcher-configmaps.yaml
@@ -37,12 +37,16 @@ parameters:
   value:
 - name: LAUNCHER_MISSIONCONTROL_OPENSHIFT_USERNAME
   displayName: OpenShift user name
-  description: OpenShift user (leave empty when using Keycloak)
+  description: OpenShift user (leave empty when using Keycloak with OpenShift as an Identity Provider or token)
   value: developer
 - name: LAUNCHER_MISSIONCONTROL_OPENSHIFT_PASSWORD
   displayName: OpenShift password
-  description: OpenShift password (leave empty when using Keycloak)  
+  description: OpenShift password (leave empty when using Keycloak with OpenShift as an Identity Provider or token)
   value: developer
+- name: LAUNCHER_MISSIONCONTROL_OPENSHIFT_IMPERSONATE_USER
+  displayName: Impersonate OpenShift users
+  description: Impersonate OpenShift users (requires a ServiceAccount with self-provisioner role)
+  value:
 - name: LAUNCHER_KEYCLOAK_URL
   displayName: KeyCloak URL
   description: The URL (with the /auth part) of a Keycloak installation to perform SSO
@@ -111,6 +115,7 @@ objects:
     launcher.missioncontrol.github.token: ${LAUNCHER_MISSIONCONTROL_GITHUB_TOKEN}
     launcher.missioncontrol.openshift.username: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_USERNAME}
     launcher.missioncontrol.openshift.password: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_PASSWORD}
+    launcher.missioncontrol.openshift.impersonate.user: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_IMPERSONATE_USER}
     launcher.missioncontrol.openshift.api.url: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_API_URL}
     launcher.missioncontrol.openshift.console.url: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL}
     launcher.backend.artemis.url: ${LAUNCHER_BACKEND_ARTEMIS_URL}

--- a/openshift/split/launcher-secrets.yaml
+++ b/openshift/split/launcher-secrets.yaml
@@ -1,5 +1,10 @@
 kind: Template
 apiVersion: v1
+parameters:
+- name: LAUNCHER_MISSIONCONTROL_OPENSHIFT_TOKEN
+  displayName: OpenShift token
+  description: OpenShift token (leave empty when using Keycloak with OpenShift as an Identity Provider or user/password above)
+  value:
 objects:
 - apiVersion: v1
   kind: Secret
@@ -7,4 +12,5 @@ objects:
     name: launcher
   data:
     launcher.missioncontrol.openshift.clusters.subscription.token:
+    launcher.missioncontrol.openshift.token: ${LAUNCHER_MISSIONCONTROL_OPENSHIFT_TOKEN}
 


### PR DESCRIPTION
Add support for LAUNCHER_MISSIONCONTROL_OPENSHIFT_TOKEN secret and LAUNCHER_MISSIONCONTROL_OPENSHIFT_IMPERSONATE_USER flag in configmap

scripts/create-unified-template.sh > openshift/launcher-template.yaml