### PR TITLE
feat(scripts): Minishift script can now be used without cloning

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -2,7 +2,25 @@
 
 The OpenShift templates that will create all the necessary services to run the Launcher
         
-== Setup
+== Installation
+
+=== Minishift
+
+Before starting the installation make sure that:
+
+ - Minishift is running
+ - You are logged in using `oc login`
+ - Your GitHub Username is set using `git config --set github.user <user>`
+ - Your GitHub Token is set using `git config --set github.token <token>`
+
+After that simply run the following:
+
+[source,bash]
+----
+    curl -s https://raw.githubusercontent.com/fabric8-launcher/launcher-openshift-templates/master/scripts/minishift/install.sh | bash
+----
+
+=== Any OpenShift
 
 To install this template in your OpenShift project run the following:
 

--- a/scripts/minishift/install.sh
+++ b/scripts/minishift/install.sh
@@ -1,5 +1,29 @@
 #!/bin/bash
 
+case "$1" in
+    ""|"--remote")
+        BASE="https://raw.githubusercontent.com/fabric8-launcher/launcher-openshift-templates/master"
+        PROPS=$(curl -s $BASE/released.properties)
+        ;;
+    "--local")
+        BASE=.
+        PROPS=$(cat released.properties)
+        ;;
+    "--delete")
+        oc delete project launcher
+        exit
+        ;;
+    *)
+        echo "Invalid argument: $1"
+        echo "Usage: install [--local] [--remote] [--delete]"
+        exit
+        ;;
+esac
+
+for p in $PROPS; do
+    PARAMS="$PARAMS -p $p"
+done
+
 echo This script will install the Launcher in Minishift. Make sure that:
 echo 
 echo  - Minishift is running 
@@ -7,22 +31,23 @@ echo  - You have run oc login previously
 echo  - Your GitHub Username is correct [found from git config github.user]: $(git config github.user)
 echo  - Your GitHub Token is correct [found from git config github.token]: *REDACTED*
 echo 
-echo Press any key to continue ...
+echo Press ENTER to continue ...
 read 
 
 echo Creating launcher project ...
 oc new-project launcher
 
 echo Processing the template and installing ...
-oc process --local -f openshift/launcher-template.yaml \
+oc process --local -f $BASE/openshift/launcher-template.yaml \
    LAUNCHER_KEYCLOAK_URL= \
    LAUNCHER_KEYCLOAK_REALM= \
    LAUNCHER_MISSIONCONTROL_GITHUB_USERNAME=$(git config github.user) \
    LAUNCHER_MISSIONCONTROL_GITHUB_TOKEN=$(git config github.token) \
    LAUNCHER_MISSIONCONTROL_OPENSHIFT_CONSOLE_URL=$(minishift console --url | sed 's/\/console//') \
-   --param-file=released.properties -o yaml | oc create -f -
+   $PARAMS -o yaml | oc create -f -
 
 echo Enabling Launcher Creator
 oc set env dc/launcher-frontend LAUNCHER_CREATOR_ENABLED=true
 
 echo All set! Enjoy!
+


### PR DESCRIPTION
The script by default now gets the template direct from the github
repository. This makes it possible to simply use
`curl -s https://raw.githubusercontent.com/fabric8-launcher/launcher-openshift-templates/master/scripts/minishift/install.sh | bash`
to install witout having to first clone the repository.